### PR TITLE
Add Jest tests for farm stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -446,6 +446,11 @@
             renderFPOs();
             updateSelectors();
             renderExpenses();
+
+            const totalArea = farmData.plots.reduce((sum, plot) => sum + plot.area, 0);
+            document.getElementById('totalArea').textContent = totalArea;
+            document.getElementById('totalPlots').textContent = farmData.plots.length;
+            document.getElementById('activeFPOs').textContent = farmData.fpos.length;
         }
 
         // Render plots

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "va-farmcontract",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.6.4",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('initApp', () => {
+  let dom;
+
+  beforeAll(() => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+    dom = new JSDOM(html, { runScripts: 'dangerously' });
+    dom.window.initApp();
+  });
+
+  test('updates total plots from farmData', () => {
+    const document = dom.window.document;
+    const farmData = dom.window.eval('farmData');
+    expect(document.getElementById('totalPlots').textContent)
+      .toBe(String(farmData.plots.length));
+  });
+
+  test('updates total area from farmData', () => {
+    const document = dom.window.document;
+    const farmData = dom.window.eval('farmData');
+    const totalArea = farmData.plots.reduce((sum, p) => sum + p.area, 0);
+    expect(document.getElementById('totalArea').textContent)
+      .toBe(String(totalArea));
+  });
+
+  test('updates active FPO count from farmData', () => {
+    const document = dom.window.document;
+    const farmData = dom.window.eval('farmData');
+    expect(document.getElementById('activeFPOs').textContent)
+      .toBe(String(farmData.fpos.length));
+  });
+});


### PR DESCRIPTION
## Summary
- add npm `package.json` for Jest setup
- update `initApp` to populate stats from `farmData`
- create Jest test validating DOM stats
- ignore node dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68458485d6b4832787efaa3c7646c142